### PR TITLE
Replace log with logrus

### DIFF
--- a/internal/tf5muxprovider/main.go
+++ b/internal/tf5muxprovider/main.go
@@ -1,7 +1,7 @@
 package tf5muxprovider
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
 )

--- a/internal/tf5to6provider/main.go
+++ b/internal/tf5to6provider/main.go
@@ -1,7 +1,7 @@
 package tf5to6provider
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
 )

--- a/internal/tf6muxprovider/main.go
+++ b/internal/tf6muxprovider/main.go
@@ -1,7 +1,7 @@
 package tf6muxprovider
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
 )

--- a/internal/tf6to5provider/main.go
+++ b/internal/tf6to5provider/main.go
@@ -1,7 +1,7 @@
 package tf6to5provider
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
 )

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"


### PR DESCRIPTION
Namespace(repository='github.com/sourcegraph-ce/terraform-provider-corner', batch_change_name='log-provider-go-with-python-script', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script)